### PR TITLE
Fix physical normalization with importance weights

### DIFF
--- a/tests/test_compute_norm_grid.py
+++ b/tests/test_compute_norm_grid.py
@@ -1,0 +1,56 @@
+import numpy as np
+from scipy.stats import skewnorm
+from scipy.special import erf
+
+from norm_computer import compute_norm_grid as cn
+
+
+def test_importance_weighting_unbiased(monkeypatch):
+    """Monte Carlo estimator remains unbiased with mismatched sampling."""
+    # Stub lens model and solver so selection depends on logMstar only
+    k_prime = np.sqrt(2) / 2.5
+
+    class DummyModel:
+        def __init__(self, logMstar, logMh, logRe, zl=0.3, zs=2.0):
+            self.logMstar = logMstar
+
+        def mu_from_rt(self, x):
+            # Produces selection: 0.5*(1+erf(logMstar-11.4))
+            return 10 ** (k_prime * (self.logMstar - 11.4))
+
+    def dummy_solver(model, beta_unit):
+        return 0.0, 0.0
+
+    monkeypatch.setattr(cn, "LensModel", DummyModel)
+    monkeypatch.setattr(cn, "solve_single_lens", dummy_solver)
+
+    # Samples drawn from simple Gaussian distributions
+    n_samples = 20000
+    samples, Mh_range = cn.generate_lens_samples_no_alpha(
+        n_samples=n_samples, seed=0
+    )
+
+    estimate = cn.compute_A_phys_eta(
+        mu_DM_cnst=13.0,
+        beta_DM=0.0,
+        xi_DM=0.0,
+        sigma_DM=0.2,
+        samples=samples,
+        Mh_range=Mh_range,
+        ms=0.0,
+        sigma_m=1.0,
+        m_lim=0.0,
+    )
+
+    # Ground truth from target distribution
+    rng = np.random.default_rng(0)
+    a_skew = 10 ** cn.MODEL_P["log_s_star"]
+    mu_star = cn.MODEL_P["mu_star"]
+    sigma_star = cn.MODEL_P["sigma_star"]
+    logMstar_target = skewnorm.rvs(
+        a=a_skew, loc=mu_star, scale=sigma_star, size=200000, random_state=rng
+    )
+    g = 0.5 * (1 + erf(logMstar_target - 11.4))
+    true_val = np.mean(g ** 2)
+
+    assert np.isclose(estimate, true_val, rtol=0.02)


### PR DESCRIPTION
## Summary
- Correct A_phys normalization by dividing by sampling PDFs for stellar mass and size
- Normalize using all sample weights, not just valid lenses
- Add regression test demonstrating unbiased estimates despite sampling/target mismatch

## Testing
- `pip install numpy scipy pytest -q` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest tests/test_compute_norm_grid.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68921f8a1b48832d9cdaf5fddcb38afd