### PR TITLE
Integrate ms distribution into Aeta normalization sampling

### DIFF
--- a/tests/test_compute_norm_grid.py
+++ b/tests/test_compute_norm_grid.py
@@ -40,9 +40,6 @@ def test_importance_weighting_unbiased(monkeypatch):
         Mh_range=Mh_range,
         sigma_m=1.0,
         m_lim=0.0,
-        alpha_s=-1.3,
-        m_s_star=24.5,
-        n_ms=200,
     )
 
     # Ground truth from target distribution


### PR DESCRIPTION
## Summary
- Extend lens sample generator to draw source magnitudes from the Schechter-like distribution
- Compute A_eta using sampled source magnitudes, performing Monte Carlo marginalization directly
- Update unit test to use new ms-aware functions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy -q` *(fails: Could not find a version that satisfies the requirement numpy (403 Forbidden))*


------
https://chatgpt.com/codex/tasks/task_e_6893027de0c4832da5b9ce2dc961dccd