### PR TITLE
refactor: decouple physical response tables from η weighting

### DIFF
--- a/tests/test_compute_norm_grid.py
+++ b/tests/test_compute_norm_grid.py
@@ -28,16 +28,26 @@ def test_importance_weighting_unbiased(monkeypatch):
     # Samples drawn from simple Gaussian distributions
     n_samples = 20000
     samples, Mh_range = cn.generate_lens_samples_no_alpha(
-        n_samples=n_samples, seed=0
+        n_samples=n_samples, seed=0, mu_DM=13.0, sigma_DM=0.2
+    )
+    Mh_min, Mh_max = Mh_range
+    logMh_grid = np.linspace(Mh_min, Mh_max, 50)
+    logalpha_grid = np.array([0.0])
+
+    muA_tab, muB_tab = cn.build_physical_response_table(
+        samples, logMh_grid, logalpha_grid
     )
 
-    estimate = cn.compute_A_phys_eta(
+    estimate = cn.compute_A_eta_from_table(
+        muA_tab,
+        muB_tab,
+        samples,
+        logMh_grid,
+        logalpha_grid,
         mu_DM_cnst=13.0,
         beta_DM=0.0,
         xi_DM=0.0,
         sigma_DM=0.2,
-        samples=samples,
-        Mh_range=Mh_range,
         sigma_m=1.0,
         m_lim=0.0,
     )


### PR DESCRIPTION
## Summary
- generate lens samples without halo mass and build a reusable physical response table
- add hyper-parameter weighting on the precomputed table with convenience wrapper
- update tests for the new two-stage A(η) computation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy scipy` *(fails: Cannot connect to proxy. Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689330bd1f88832dad95bf54437aeb07